### PR TITLE
Add Screen Event Support

### DIFF
--- a/Example/BasicExample/BasicExample/BasicExampleApp.swift
+++ b/Example/BasicExample/BasicExample/BasicExampleApp.swift
@@ -19,7 +19,7 @@ struct BasicExampleApp: App {
 
 extension Analytics {
     static var main: Analytics {
-        let analytics = Analytics(configuration: Configuration(writeKey: "")
+        let analytics = Analytics(configuration: Configuration(writeKey: "<SEGMENT_WRITE_KEY>")
                     .flushAt(3)
                     .trackApplicationLifecycleEvents(true))
         analytics.add(plugin: SprigDestination())

--- a/Example/BasicExample/BasicExample/BasicExampleApp.swift
+++ b/Example/BasicExample/BasicExample/BasicExampleApp.swift
@@ -19,7 +19,7 @@ struct BasicExampleApp: App {
 
 extension Analytics {
     static var main: Analytics {
-        let analytics = Analytics(configuration: Configuration(writeKey: "<YOUR WRITE KEY>")
+        let analytics = Analytics(configuration: Configuration(writeKey: "")
                     .flushAt(3)
                     .trackApplicationLifecycleEvents(true))
         analytics.add(plugin: SprigDestination())

--- a/Example/BasicExample/BasicExample/ContentView.swift
+++ b/Example/BasicExample/BasicExample/ContentView.swift
@@ -18,6 +18,11 @@ struct ContentView: View {
                     Text("Track")
                 }).padding(6)
                 Button(action: {
+                    Analytics.main.screen(title: "iOS Segment Screen", properties: ["segmentActionsiOS": true, "deviceType": "iOS"])
+                }, label: {
+                    Text("Screen")
+                }).padding(6)
+                Button(action: {
                     Analytics.main.track(name: "Signed Out")
                 }, label: {
                     Text("Signed Out")

--- a/Example/BasicExample/BasicExample/ContentView.swift
+++ b/Example/BasicExample/BasicExample/ContentView.swift
@@ -15,10 +15,20 @@ struct ContentView: View {
                 Button(action: {
                     Analytics.main.track(name: "Track", properties: ["age": 3, "item": "cookies"])
                 }, label: {
+                    Text("Track with Props")
+                }).padding(6)
+                Button(action: {
+                    Analytics.main.track(name: "Track")
+                }, label: {
                     Text("Track")
                 }).padding(6)
                 Button(action: {
                     Analytics.main.screen(title: "iOS Segment Screen", properties: ["segmentActionsiOS": true, "deviceType": "iOS"])
+                }, label: {
+                    Text("Screen with props")
+                }).padding(6)
+                Button(action: {
+                    Analytics.main.screen(title: "iOS Segment Screen")
                 }, label: {
                     Text("Screen")
                 }).padding(6)

--- a/Sources/SegmentSprig/SprigDestination.swift
+++ b/Sources/SegmentSprig/SprigDestination.swift
@@ -61,7 +61,7 @@ public class SprigDestination: DestinationPlugin {
     public func screen(event: ScreenEvent) -> ScreenEvent? {
         guard let eventName = event.name else {return}
         let properties: [String: Any?] = event.properties?.dictionaryValue as? [String: Any?] ?? [:]
-        Sprig.shared.track(eventName: event.name,
+        Sprig.shared.track(eventName: eventName,
                            userId: event.userId,
                            partnerAnonymousId: event.anonymousId,
                            properties: properties) { surveyState in

--- a/Sources/SegmentSprig/SprigDestination.swift
+++ b/Sources/SegmentSprig/SprigDestination.swift
@@ -59,8 +59,9 @@ public class SprigDestination: DestinationPlugin {
     }
     
     public func screen(event: ScreenEvent) -> ScreenEvent? {
+        guard let eventName = event.name else {return}
         let properties: [String: Any?] = event.properties?.dictionaryValue as? [String: Any?] ?? [:]
-        Sprig.shared.track(eventName: event.name!,
+        Sprig.shared.track(eventName: event.name,
                            userId: event.userId,
                            partnerAnonymousId: event.anonymousId,
                            properties: properties) { surveyState in

--- a/Sources/SegmentSprig/SprigDestination.swift
+++ b/Sources/SegmentSprig/SprigDestination.swift
@@ -59,7 +59,7 @@ public class SprigDestination: DestinationPlugin {
     }
     
     public func screen(event: ScreenEvent) -> ScreenEvent? {
-        guard let eventName = event.name else {return}
+        guard let eventName = event.name else {return event}
         let properties: [String: Any?] = event.properties?.dictionaryValue as? [String: Any?] ?? [:]
         Sprig.shared.track(eventName: eventName,
                            userId: event.userId,

--- a/Sources/SegmentSprig/SprigDestination.swift
+++ b/Sources/SegmentSprig/SprigDestination.swift
@@ -58,6 +58,20 @@ public class SprigDestination: DestinationPlugin {
         return event
     }
     
+    public func screen(event: ScreenEvent) -> ScreenEvent? {
+        let properties: [String: Any?] = event.properties?.dictionaryValue as? [String: Any?] ?? [:]
+        Sprig.shared.track(eventName: event.name!,
+                           userId: event.userId,
+                           partnerAnonymousId: event.anonymousId,
+                           properties: properties) { surveyState in
+            guard surveyState == .ready else { return }
+            if let vc = UIApplication.shared.topViewController() {
+                Sprig.shared.presentSurvey(from: vc)
+            }
+        }
+        return event
+    }
+    
     // switch to a new user id
     public func alias(event: AliasEvent) -> AliasEvent? {
         guard let userId = event.userId else { return event }
@@ -133,6 +147,7 @@ extension UIApplication {
         return topViewController
     }
 }
+
 private struct SprigSettings: Codable {
     let envId: String
 }

--- a/Sources/SegmentSprig/Version.swift
+++ b/Sources/SegmentSprig/Version.swift
@@ -1,1 +1,1 @@
-internal let __destination_version = "1.2.4"
+internal let __destination_version = "1.2.5"


### PR DESCRIPTION
## Added Screen event support

This PR adds a `screen` method to the plugin to support Segment `screen` events as Sprig code events.

## How Has This Been Tested?

This has been tested in the example app included in this repo
