### PR TITLE
STUDIES-7247 attach package version header

### DIFF
--- a/Sources/SegmentSprig/SprigDestination.swift
+++ b/Sources/SegmentSprig/SprigDestination.swift
@@ -30,7 +30,13 @@ public class SprigDestination: DestinationPlugin {
         // Grab the settings from segment
         guard let sprigSettings: SprigSettings = settings.integrationSettings(forPlugin: self) else { return }
         guard sprigSettings.envId != "" else { return }
-        Sprig.shared.configure(withEnvironment: sprigSettings.envId, configuration: ["x-ul-installation-method": "ios-segment"])
+
+        var configuration: [String: Any] = [
+            "x-ul-installation-method": "ios-segment",
+            "x-ul-package-version": SprigDestination.version()
+        ]
+
+        Sprig.shared.configure(withEnvironment: sprigSettings.envId, configuration: configuration)
     }
     
     public func identify(event: IdentifyEvent) -> IdentifyEvent? {


### PR DESCRIPTION
- currently we store just the package version (e.g. 1.2.5) for ios-segment in the sdkVersions table
- but only the mobile-sdk-version header is used for recording sdk diagnostics, so therell be mistmatch of versions which means it wont be shown on the sdk & traffic page
- this sends a new header which will have the package version