### PR TITLE
STUDIES-7274 Update Release Version

### DIFF
--- a/Example/BasicExample/BasicExample.xcodeproj/project.pbxproj
+++ b/Example/BasicExample/BasicExample.xcodeproj/project.pbxproj
@@ -616,7 +616,7 @@
 			repositoryURL = "https://github.com/UserLeap/userleap-ios-sdk-releases";
 			requirement = {
 				kind = exactVersion;
-				version = 4.13.0;
+				version = 4.20.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,17 +5,26 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/segmentio/analytics-swift.git",
       "state" : {
-        "revision" : "79fb17a5d4abf8f80e6a0935e57c7df7b670a6c0",
-        "version" : "1.4.1"
+        "revision" : "51f56b972de8daee251f18fd2c91fa3a33c8d77e",
+        "version" : "1.5.2"
+      }
+    },
+    {
+      "identity" : "jsonsafeencoder-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/segmentio/jsonsafeencoder-swift.git",
+      "state" : {
+        "revision" : "8b70dc8c01b7b041912e30e29d2b488a43f782ac",
+        "version" : "1.0.1"
       }
     },
     {
       "identity" : "sovran-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/segmentio/Sovran-Swift.git",
+      "location" : "https://github.com/segmentio/sovran-swift.git",
       "state" : {
-        "revision" : "944c17d7c46bd95fc37f09136cabd172be5b413b",
-        "version" : "1.0.3"
+        "revision" : "64f3b5150c282a34af4578188dce2fd597e600e3",
+        "version" : "1.1.0"
       }
     },
     {
@@ -23,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/UserLeap/userleap-ios-sdk-releases/",
       "state" : {
-        "revision" : "b6e44c99f0b763a026f50c771b0f550a103ff065",
-        "version" : "4.19.2"
+        "revision" : "25145e5cde7d31c4adcc1b0216ecd3a4c74e93d5",
+        "version" : "4.20.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/UserLeap/userleap-ios-sdk-releases/",
-            from: "4.19.2"
+            exact: "4.20.2"
         )
     ],
     targets: [

--- a/Sources/SegmentSprig/Version.swift
+++ b/Sources/SegmentSprig/Version.swift
@@ -1,1 +1,1 @@
-internal let __destination_version = "1.2.5"
+internal let __destination_version = "1.2.6"


### PR DESCRIPTION
# Description
- add: `x-ul-package-header` support
- chore: pin iOS SDK version to 4.20.2

# Testing
<img width="896" alt="Screenshot 2024-02-02 at 1 18 12 PM" src="https://github.com/UserLeap/analytics-swift-sprig/assets/98436707/2543942d-4e36-43f3-b397-65ff8b1ebc3f">

![IMG_6550](https://github.com/UserLeap/analytics-swift-sprig/assets/98436707/7c86a22a-42dd-4ab9-a542-37670f671fea)

