### PR TITLE
Revert "Bump Sprig iOS SDK to 4.21.2 (#39)"

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/UserLeap/userleap-ios-sdk-releases/",
       "state" : {
-        "revision" : "d76ba0d3024eeb7cb360db3b692d18d3958ee519",
-        "version" : "4.21.2"
+        "revision" : "25145e5cde7d31c4adcc1b0216ecd3a4c74e93d5",
+        "version" : "4.20.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/UserLeap/userleap-ios-sdk-releases/",
-            exact: "4.21.2"
+            exact: "4.21.1"
         )
     ],
     targets: [

--- a/Sources/SegmentSprig/Version.swift
+++ b/Sources/SegmentSprig/Version.swift
@@ -1,1 +1,1 @@
-internal let __destination_version = "1.2.8"
+internal let __destination_version = "1.2.7"


### PR DESCRIPTION
This reverts commit 34bb6e1545b7c6383792cbe76effe38140eb6841.