### PR TITLE
Bump Sprig iOS SDK version to 4.23.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
+## Segment config
+Config.plist
+
 ## User settings
 xcuserdata/
 Example/BasicExample/BasicExample/Config.plist

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/UserLeap/userleap-ios-sdk-releases/",
-            exact: "4.23.1"
+            exact: "4.23.8"
         )
     ],
     targets: [

--- a/Sources/SegmentSprig/Version.swift
+++ b/Sources/SegmentSprig/Version.swift
@@ -1,1 +1,1 @@
-internal let __destination_version = "1.3.0"
+internal let __destination_version = "1.3.1"


### PR DESCRIPTION
Bumps Sprig iOS SDK version to 4.23.8

iOS Changelog from the last plugin release:

4.23.8
- fix: Fix for race condition that could potentially cause blank surveys.

4.23.7
- fix: Fix for session replays ignoring max duration value from server.

4.23.6
- fix: Fix for session replays capture issue where large amounts of text were causing replay capture to shut down in SwiftUI apps.

4.23.5
- add: Baseline support for SwiftUI in session replays.

4.23.4
- fix: Fixed issues with session replays.