### PR TITLE
Bump Sprig SDK Version to 4.24.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         ),
         .package(
             url: "https://github.com/UserLeap/userleap-ios-sdk-releases/",
-            exact: "4.23.8"
+            exact: "4.24.1"
         )
     ],
     targets: [

--- a/Sources/SegmentSprig/Version.swift
+++ b/Sources/SegmentSprig/Version.swift
@@ -1,1 +1,1 @@
-internal let __destination_version = "1.3.1"
+internal let __destination_version = "1.3.2"


### PR DESCRIPTION
Bumps Sprig SDK version to 4.24.1 in `Package.swift`